### PR TITLE
Koala 1423 support session connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ logs/
 .venv*
 *.sublime*
 .python-version
+venv/

--- a/dbt/adapters/databricks/__version__.py
+++ b/dbt/adapters/databricks/__version__.py
@@ -1,1 +1,1 @@
-version: str = "1.8.6"
+version: str = "1.8.6a14"

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -1109,7 +1109,7 @@ class DatabricksSessionConnectionManager(DatabricksConnectionManager):
     def set_connection_name(
         self, name: Optional[str] = None, query_header_context: Any = None
     ) -> Connection:
-        SparkConnectionManager.set_connection_name(self, name)
+        return SparkConnectionManager.set_connection_name(self, name)
 
     def add_query(
         self,

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -1097,9 +1097,7 @@ class DatabricksSessionConnectionManager(DatabricksConnectionManager):
 
     def compare_dbr_version(self, major: int, minor: int) -> int:
         version = (major, minor)
-        connection = (
-            self.get_thread_connection().handle
-        )
+        connection = self.get_thread_connection().handle
         dbr_version = connection.dbr_version
         return (dbr_version > version) - (dbr_version < version)
 
@@ -1120,23 +1118,24 @@ class DatabricksSessionConnectionManager(DatabricksConnectionManager):
         *,
         close_cursor: bool = False,
     ) -> Tuple[Connection, Any]:
-        return SparkConnectionManager.add_query(
-            self, sql, auto_begin, bindings, abridge_sql_log
-        )
+        return SparkConnectionManager.add_query(self, sql, auto_begin, bindings, abridge_sql_log)
 
     def list_schemas(self, database: str, schema: Optional[str] = None) -> "Table":
-        raise NotImplementedError("list_schemas is not implemented for DatabricksSessionConnectionManager - should call the list_schemas macro instead")
+        raise NotImplementedError(
+            "list_schemas is not implemented for DatabricksSessionConnectionManager - should call the list_schemas macro instead"
+        )
 
     def list_tables(self, database: str, schema: str, identifier: Optional[str] = None) -> "Table":
-        raise NotImplementedError("list_tables is not implemented for DatabricksSessionConnectionManager - should call the list_tables macro instead")
+        raise NotImplementedError(
+            "list_tables is not implemented for DatabricksSessionConnectionManager - should call the list_tables macro instead"
+        )
 
     @classmethod
     def open(cls, connection: Connection) -> Connection:
         from dbt.adapters.spark.session import Connection
         from dbt.adapters.databricks.session_connection import DatabricksSessionConnectionWrapper
-        handle = DatabricksSessionConnectionWrapper(
-            Connection()
-        )
+
+        handle = DatabricksSessionConnectionWrapper(Connection())
         connection.handle = handle
         connection.state = ConnectionState.OPEN
         return connection

--- a/dbt/adapters/databricks/connections.py
+++ b/dbt/adapters/databricks/connections.py
@@ -70,9 +70,7 @@ from dbt.adapters.events.types import ConnectionUsed
 from dbt.adapters.events.types import NewConnection
 from dbt.adapters.events.types import SQLQuery
 from dbt.adapters.events.types import SQLQueryStatus
-from dbt.adapters.spark.connections import (
-    SparkConnectionManager,
-)
+from dbt.adapters.spark.connections import SparkConnectionManager
 from dbt_common.events.contextvars import get_node_info
 from dbt_common.events.functions import fire_event
 from dbt_common.exceptions import DbtInternalError

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -38,11 +38,11 @@ from dbt.adapters.contracts.connection import Connection
 from dbt.adapters.contracts.relation import RelationConfig
 from dbt.adapters.contracts.relation import RelationType
 from dbt.adapters.databricks.column import DatabricksColumn
-from dbt.adapters.databricks.connections import DatabricksConnectionManager
+from dbt.adapters.databricks.connections import DatabricksConnectionManager, DatabricksSessionConnectionManager
 from dbt.adapters.databricks.connections import DatabricksDBTConnection
 from dbt.adapters.databricks.connections import DatabricksSQLConnectionWrapper
 from dbt.adapters.databricks.connections import ExtendedSessionConnectionManager
-from dbt.adapters.databricks.connections import USE_LONG_SESSIONS
+from dbt.adapters.databricks.connections import USE_LONG_SESSIONS, USE_SESSION_CONNECTION
 from dbt.adapters.databricks.python_submissions import (
     DbtDatabricksAllPurposeClusterPythonJobHelper,
 )
@@ -148,7 +148,9 @@ class DatabricksAdapter(SparkAdapter):
     Relation = DatabricksRelation
     Column = DatabricksColumn
 
-    if USE_LONG_SESSIONS:
+    if USE_SESSION_CONNECTION:
+        ConnectionManager: Type[DatabricksConnectionManager] = DatabricksSessionConnectionManager
+    elif USE_LONG_SESSIONS:
         ConnectionManager: Type[DatabricksConnectionManager] = ExtendedSessionConnectionManager
     else:
         ConnectionManager = DatabricksConnectionManager
@@ -207,10 +209,12 @@ class DatabricksAdapter(SparkAdapter):
         If `database` is `None`, fallback to executing `show databases` because
         `list_schemas` tries to collect schemas from all catalogs when `database` is `None`.
         """
-        if database is not None:
+        if database is not None and not USE_SESSION_CONNECTION:
             results = self.connections.list_schemas(database=database)
         else:
-            results = self.execute_macro(LIST_SCHEMAS_MACRO_NAME, kwargs={"database": database})
+            results = self.execute_macro(
+                LIST_SCHEMAS_MACRO_NAME, kwargs={"database": database}
+            )
         return [row[0] for row in results]
 
     def check_schema_exists(self, database: Optional[str], schema: str) -> bool:
@@ -281,7 +285,7 @@ class DatabricksAdapter(SparkAdapter):
         kwargs = {"relation": relation}
 
         new_rows: List[Tuple[str, Optional[str]]]
-        if all([relation.database, relation.schema]):
+        if all([relation.database, relation.schema]) and not USE_SESSION_CONNECTION:
             tables = self.connections.list_tables(
                 database=relation.database, schema=relation.schema  # type: ignore[arg-type]
             )

--- a/dbt/adapters/databricks/impl.py
+++ b/dbt/adapters/databricks/impl.py
@@ -38,7 +38,10 @@ from dbt.adapters.contracts.connection import Connection
 from dbt.adapters.contracts.relation import RelationConfig
 from dbt.adapters.contracts.relation import RelationType
 from dbt.adapters.databricks.column import DatabricksColumn
-from dbt.adapters.databricks.connections import DatabricksConnectionManager, DatabricksSessionConnectionManager
+from dbt.adapters.databricks.connections import (
+    DatabricksConnectionManager,
+    DatabricksSessionConnectionManager,
+)
 from dbt.adapters.databricks.connections import DatabricksDBTConnection
 from dbt.adapters.databricks.connections import DatabricksSQLConnectionWrapper
 from dbt.adapters.databricks.connections import ExtendedSessionConnectionManager
@@ -212,9 +215,7 @@ class DatabricksAdapter(SparkAdapter):
         if database is not None and not USE_SESSION_CONNECTION:
             results = self.connections.list_schemas(database=database)
         else:
-            results = self.execute_macro(
-                LIST_SCHEMAS_MACRO_NAME, kwargs={"database": database}
-            )
+            results = self.execute_macro(LIST_SCHEMAS_MACRO_NAME, kwargs={"database": database})
         return [row[0] for row in results]
 
     def check_schema_exists(self, database: Optional[str], schema: str) -> bool:

--- a/dbt/adapters/databricks/session_connection.py
+++ b/dbt/adapters/databricks/session_connection.py
@@ -10,6 +10,7 @@ DBR_VERSION_REGEX = re.compile(r"([1-9][0-9]*)\.(x|0|[1-9][0-9]*)")
 class DatabricksSessionConnectionWrapper(SessionConnectionWrapper):
 
     _is_cluster: bool
+    _dbr_version: Tuple[int, int]
 
     def __init__(self, handle: Connection) -> None:
         super().__init__(handle)

--- a/dbt/adapters/databricks/session_connection.py
+++ b/dbt/adapters/databricks/session_connection.py
@@ -1,0 +1,41 @@
+import re
+import sys
+from typing import Tuple
+from dbt.adapters.spark.session import SessionConnectionWrapper, Connection
+
+
+DBR_VERSION_REGEX = re.compile(r"([1-9][0-9]*)\.(x|0|[1-9][0-9]*)")
+
+
+class DatabricksSessionConnectionWrapper(SessionConnectionWrapper):
+
+    _is_cluster: bool
+
+    def __init__(self, handle: Connection) -> None:
+        super().__init__(handle)
+        self._is_cluster = True
+        self.cursor()
+
+    @property
+    def dbr_version(self) -> Tuple[int, int]:
+        if not hasattr(self, "_dbr_version"):
+            if self._is_cluster:
+                with self._cursor() as cursor:
+                    cursor.execute("SET spark.databricks.clusterUsageTags.sparkVersion")
+                    results = cursor.fetchone()
+                    if results:
+                        dbr_version: str = results[1]
+
+                m = DBR_VERSION_REGEX.search(dbr_version)
+                assert m, f"Unknown DBR version: {dbr_version}"
+                major = int(m.group(1))
+                try:
+                    minor = int(m.group(2))
+                except ValueError:
+                    minor = sys.maxsize
+                self._dbr_version = (major, minor)
+            else:
+                # Assuming SQL Warehouse uses the latest version.
+                self._dbr_version = (sys.maxsize, sys.maxsize)
+
+        return self._dbr_version

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -113,6 +113,7 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
         test_http_headers(["a", "b"])
         test_http_headers({"a": 1, "b": 2})
 
+    @pytest.mark.skip_profile("session_connection")
     def test_invalid_custom_user_agent(self):
         with pytest.raises(DbtValidationError) as excinfo:
             config = self._get_config()
@@ -123,6 +124,7 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
 
         assert "Invalid invocation environment" in str(excinfo.value)
 
+    @pytest.mark.skip_profile("session_connection")
     def test_custom_user_agent(self):
         config = self._get_config()
         adapter = DatabricksAdapter(config, get_context("spawn"))
@@ -137,12 +139,14 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
                 connection = adapter.acquire_connection("dummy")
                 connection.handle  # trigger lazy-load
 
+    @pytest.mark.skip_profile("session_connection")
     def test_environment_single_http_header(self):
         self._test_environment_http_headers(
             http_headers_str='{"test":{"jobId":1,"runId":12123}}',
             expected_http_headers=[("test", '{"jobId": 1, "runId": 12123}')],
         )
 
+    @pytest.mark.skip_profile("session_connection")
     def test_environment_multiple_http_headers(self):
         self._test_environment_http_headers(
             http_headers_str='{"test":{"jobId":1,"runId":12123},"dummy":{"jobId":1,"runId":12123}}',
@@ -152,6 +156,7 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
             ],
         )
 
+    @pytest.mark.skip_profile("session_connection")
     def test_environment_users_http_headers_intersection_error(self):
         with pytest.raises(DbtValidationError) as excinfo:
             self._test_environment_http_headers(
@@ -162,6 +167,7 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
 
         assert "Intersection with reserved http_headers in keys: {'t'}" in str(excinfo.value)
 
+    @pytest.mark.skip_profile("session_connection")
     def test_environment_users_http_headers_union_success(self):
         self._test_environment_http_headers(
             http_headers_str='{"t":{"jobId":1,"runId":12123},"d":{"jobId":1,"runId":12123}}',
@@ -173,6 +179,7 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
             ],
         )
 
+    @pytest.mark.skip_profile("session_connection")
     def test_environment_http_headers_string(self):
         self._test_environment_http_headers(
             http_headers_str='{"string":"some-string"}',
@@ -272,6 +279,7 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
 
         return connect
 
+    @pytest.mark.skip_profile("session_connection")
     def test_databricks_sql_connector_connection(self):
         self._test_databricks_sql_connector_connection(self._connect_func())
 
@@ -294,6 +302,7 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
             assert len(connection.credentials.session_properties) == 1
             assert connection.credentials.session_properties["spark.sql.ansi.enabled"] == "true"
 
+    @pytest.mark.skip_profile("session_connection")
     def test_databricks_sql_connector_catalog_connection(self):
         self._test_databricks_sql_connector_catalog_connection(
             self._connect_func(expected_catalog="main")
@@ -317,6 +326,7 @@ class TestDatabricksAdapter(DatabricksAdapterBase):
             assert connection.credentials.schema == "analytics"
             assert connection.credentials.database == "main"
 
+    @pytest.mark.skip_profile("session_connection")
     def test_databricks_sql_connector_http_header_connection(self):
         self._test_databricks_sql_connector_http_header_connection(
             {"aaa": "xxx"}, self._connect_func(expected_http_headers=[("aaa", "xxx")])

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,20 @@ deps =
 [testenv:unit]
 basepython = python3
 commands = {envpython} -m pytest --color=yes -v {posargs} tests/unit
+setenv =
+    DBT_DATABRICKS_SESSION_CONNECTION = False
+passenv =
+  DBT_*
+  PYTEST_ADDOPTS
+deps =
+  -r{toxinidir}/dev-requirements.txt
+  -r{toxinidir}/requirements.txt
+
+[testenv:unit-session]
+basepython = python3
+commands = {envpython} -m pytest --color=yes -v {posargs} --profile session_connection  tests/unit
+setenv =
+    DBT_DATABRICKS_SESSION_CONNECTION = True
 passenv =
   DBT_*
   PYTEST_ADDOPTS


### PR DESCRIPTION
<!-- Please review our pull request review process in CONTRIBUTING.md before your proceed. -->

Resolves #


 Resolves [[dbt-spark Issue #272](https://github.com/dbt-labs/dbt-spark/issues/272)](https://github.com/dbt-labs/dbt-spark/issues/272) for dbt-databricks adapter.

 

### Description

### Pull Request Description  

**Summary**  
This PR introduces support for defining a PySpark-based connection when using the adapter. This enhancement allows dbt to run as part of a running Databricks job cluster, expanding its usage beyond SQL warehouses or all-purpose clusters.  

**Background**  
The Spark session functionality referenced here was first discussed in [[dbt-spark Issue #272](https://github.com/dbt-labs/dbt-spark/issues/272)](https://github.com/dbt-labs/dbt-spark/issues/272).  

**Key Features**  
1. **PySpark-Based Connection**:  
   A new environment variable, `DBT_DATABRICKS_SESSION_CONNECTION`, has been introduced.  
   - When this variable is set to `True`, a new `DatabricksSessionConnectionManager` is initialized.  
   - This manager assumes that the dbt code is being executed in the context of an existing Spark session, making it possible to integrate with running Databricks job clusters.  

2. **Testing**:  
   - A new tox entry, `unit-session`, has been added to test this feature.  
   - Run the tests using `tox -e unit-session`. This entry sets the `DBT_DATABRICKS_SESSION_CONNECTION` variable to `True` and validates that basic unit tests work as expected.  

3. **Functional Testing**:  
   Functional tests were conducted using a Databricks notebook.  
   - The notebook programmatically triggered dbt while ensuring the `DBT_DATABRICKS_SESSION_CONNECTION` variable was set to `True`.  
   - These tests confirmed that dbt works seamlessly within a running Spark session.  
   - example notebook  code: 
   `os.environ["DBT_DATABRICKS_SESSION_CONNECTION"] = "True"

     res = dbtRunner().invoke(["run","--profiles-dir","/Workspace/Users/doron.kruh@yotpo.com/dbt-dbx-session-test/","--project-dir","/Workspace/Users/doron.kruh@yotpo.com/data-applications-e2e-env","--target","prod", "--select","yoda_e2e_infra_stg__aws_s3_cost"] )`

**Why This Matters**  
- Enables running dbt within existing Spark sessions, providing more flexibility for advanced Databricks workflows.  
- Expands the range of cluster types supported by dbt.  
- Supports integration with Databricks job clusters, ensuring compatibility with real-world use cases.  

**Next Steps**  
- Document this feature for users who may need it.  
- Verify compatibility with additional Databricks environments as needed.
### Checklist

- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have updated the `CHANGELOG.md` and added information about my change to the "dbt-databricks next" section.
